### PR TITLE
Instantiate the contract / set the owner / read query to get the owner (Part2)

### DIFF
--- a/src/msg.rs
+++ b/src/msg.rs
@@ -1,13 +1,18 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use cosmwasm_std::Addr;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InstantiateMsg {
-    pub owner: String,
+    pub owner: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryMsg {
+    QueryOwner {},
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,4 +1,11 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 use cosmwasm_std::Addr;
 use cw_storage_plus::Item;
 
-pub const OWNER: Item<Addr> = Item::new("owner");
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct Config {
+    pub owner: Addr,
+}
+
+pub const CONFIG: Item<Config> = Item::new("config");


### PR DESCRIPTION
## Summary

From the project instructions, this is the code for
"you should be able to instantiate the contract and set the owner"
"you should support a read query to get the owner of the smart contract"

Update from PR#1 by looking at some examples of other cosmwasm contracts from https://github.com/InterWasm/cw-contracts

## Approach

I came across some of the contracts in https://github.com/InterWasm/cw-contracts/tree/main/contracts and realized they pretty much all had a `Config` data object in [`state.rs`] that contained owner information. These contracts also have some neat logic that sets the creator of the contract as owner, if no owner is provided in the instantiate message.

I added a `match` expression in the `query` function of [`contract.rs`] which will make adding new queries easier.

Also updated the tests which is now basically a copy/paste of what I found in the example contracts mentioned above. I also added a couple tests that ensure my query function works correctly.

## Results and tests

- [x] Unit test
- [x] `cargo build`
- [ ] Lint tests