### PR TITLE
Support an execute message where an account can send coins to the contract and specify two accounts that can withdraw the coins (for simplicity, split coins evenly across the two destination accounts)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,9 +200,9 @@ dependencies = [
 
 [[package]]
 name = "cw-utils"
-version = "0.13.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "babd2c090f39d07ce5bf2556962305e795daa048ce20a93709eb591476e4a29e"
+checksum = "9dbaecb78c8e8abfd6b4258c7f4fbeb5c49a5e45ee4d910d3240ee8e1d714e1b"
 dependencies = [
  "cosmwasm-std",
  "schemars",
@@ -218,6 +218,18 @@ checksum = "993df11574f29574dd443eb0c189484bb91bc0638b6de3e32ab7f9319c92122d"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus",
+ "schemars",
+ "serde",
+]
+
+[[package]]
+name = "cw20"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cb782b8f110819a4eb5dbbcfed25ffba49ec16bbe32b4ad8da50a5ce68fec05"
+dependencies = [
+ "cosmwasm-std",
+ "cw-utils",
  "schemars",
  "serde",
 ]
@@ -557,6 +569,7 @@ dependencies = [
  "cw-multi-test",
  "cw-storage-plus",
  "cw2",
+ "cw20",
  "schemars",
  "serde",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ cosmwasm-std = "1.0.0"
 cosmwasm-storage = "1.0.0"
 cw-storage-plus = "0.13.2"
 cw2 = "0.13.2"
+cw20 = "0.13.2"
 schemars = "0.8.8"
 serde = { version = "1.0.137", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.31" }

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -1,4 +1,6 @@
 use schemars::JsonSchema;
+use cw20::Cw20ReceiveMsg;
+use cosmwasm_std::{Uint128, Uint64};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -9,10 +11,34 @@ pub struct InstantiateMsg {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
+    CreatePot {
+        /// target_addr will receive tokens when token amount threshold is met.
+        target_addr_1: String,
+        /// target_addr will receive tokens when token amount threshold is met.
+        target_addr_2: String,
+        receive_msg: Cw20ReceiveMsg,
+    },
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ReceiveMsg {
+    // Send sends token to an id with defined pot
+    Send { id: Uint64 },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
     QueryOwner {},
+    GetPot { addr: String },
+}
+
+// We define a custom struct for each query response
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct PotResponse {
+    /// target_addr is the address that will receive the pot
+    pub target_addr: String,
+    /// collected keeps information on how much is collected for this pot.
+    pub collected: String,
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,7 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use cosmwasm_std::Addr;
-use cw_storage_plus::Item;
+use cosmwasm_std::{Addr, DepsMut, StdResult, Response, Uint128, Uint64};
+use cw_storage_plus::{Item,Map};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Config {
@@ -9,3 +9,20 @@ pub struct Config {
 }
 
 pub const CONFIG: Item<Config> = Item::new("config");
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct Pot {
+    /// target_addr is the address that will receive the pot
+    pub target_addr: Addr,
+    /// collected keeps information on how much is collected for this pot.
+    pub collected: Uint128,
+}
+
+/// POT_SEQ holds the last pot ID
+pub const POTS: Map<&str, Pot> = Map::new("pot");
+
+pub fn save_pot(deps: DepsMut, pot1: &Pot, pot2: &Pot,) -> StdResult<()> {
+    // save pot with id
+    POTS.save(deps.storage, pot1.target_addr.as_str(), pot1);
+    POTS.save(deps.storage, pot2.target_addr.as_str(), pot2)
+}


### PR DESCRIPTION
And "Store the withdrawable coins for every account who has non-zero coins in the contract".

## Summary

From the project instructions, this is the code for
"Support an execute message where an account can send coins to the contract and specify two accounts that can withdraw the coins (for simplicity, split coins evenly across the two destination accounts)"

## Approach

I came across some of the contracts in https://github.com/InterWasm/cw-contracts/tree/main/contracts/cw20-pot and decided to re-use their "Create Pot" approach.

1. [state.rs] New objects that will allow creation of "Pot". It's those objects that will keep track of which address can withdraw what. "Pots" is a map that allows us to map an address to a Pot (We probably don't even need the `target_addr` in Pot). Finally we have a `save_pot` function that will save two distinct Pot objects for both addresses in the message.  
2. [msg.rs] We have a `CreatePot` message in `ExecuteMsg` that will allow users to hit our contract with information that will allow us to create the adequate Pots
3. [contract.rs] Has the logic that verifies if the `CreatePot` message is correct (is the token correct? is the amount valid? are the addresses valid?). If so calls `save_pots`. We also add all the unit tests in there.

## Results and tests

- [x] Unit test
- [x] `cargo build`
- [ ] Lint tests